### PR TITLE
ordered: optimize allocations in Append

### DIFF
--- a/code.go
+++ b/code.go
@@ -269,7 +269,8 @@ func Rev[T Reversible](x T) Reverse[T] {
 func RevAny(x any) any {
 	switch x := x.(type) {
 	default:
-		panic(fmt.Sprintf("ordered: invalid type %T", x))
+		t := reflect.TypeOf(x)
+		panic(fmt.Sprintf("ordered: invalid type %s", t))
 	case string:
 		return Rev(x)
 	case []byte:
@@ -660,7 +661,8 @@ func decode(enc []byte, x any) ([]byte, error) {
 Outer:
 	switch x := x.(type) {
 	default:
-		return nil, fmt.Errorf("ordered: invalid type %T", x)
+		t := reflect.TypeOf(x)
+		return nil, fmt.Errorf("ordered: invalid type %s", t)
 	case nil:
 		return enc, nil
 	case *any:
@@ -991,7 +993,8 @@ Outer:
 		rev ^ (opInt + opPosInt + 7),
 		rev ^ opInf:
 		// unreachable missing case: don't say errCorrupt
-		return nil, fmt.Errorf("cannot parse %s into %T", op, x)
+		t := reflect.TypeOf(x)
+		return nil, fmt.Errorf("cannot parse %s into %s", op, t)
 	}
 	return nil, errCorrupt
 }

--- a/code.go
+++ b/code.go
@@ -169,6 +169,7 @@ import (
 	"fmt"
 	"math"
 	"math/bits"
+	"reflect"
 )
 
 // opcode is the type byte for an encoded value.
@@ -376,7 +377,8 @@ func Append(enc []byte, list ...any) []byte {
 	for _, x := range list {
 		switch x := x.(type) {
 		default:
-			panic(fmt.Sprintf("ordered: invalid type %T", x))
+			t := reflect.TypeOf(x)
+			panic(fmt.Sprintf("ordered: invalid type %s", t))
 		case string:
 			enc = appendString(enc, x, 0)
 		case Reverse[string]:

--- a/code.go
+++ b/code.go
@@ -154,7 +154,7 @@ Reverse[integer] < Reverse[float64] < Reverse[float32] < Reverse[string/[]byte] 
 # Compatibility
 
 Because the encodings are expected to be used as keys and values
-in storage systems, existing encodings will not changed in future versions.
+in storage systems, existing encodings will not be changed in future versions.
 New types may be introduced.
 
 Although this package is inspired by [github.com/google/orderedcode],

--- a/code_test.go
+++ b/code_test.go
@@ -675,3 +675,19 @@ func TestDecodeNil(t *testing.T) {
 		t.Errorf("Decode(enc, nil, nil, &x) = %v, x=%d; want nil, x=3", err, x)
 	}
 }
+
+func BenchmarkAppend(b *testing.B) {
+	b.Run("Simple", func(b *testing.B) {
+		b.ReportAllocs()
+		buf := make([]byte, 256)
+		for i := 0; i < b.N; i++ {
+			var (
+				i1, i2 int     = 1, 2
+				u      uint64  = 256
+				f      float64 = 1.61
+				s              = "abc"
+			)
+			Append(buf[:0], i1, i2, i2, i2, u, u, u, f, s)
+		}
+	})
+}

--- a/code_test.go
+++ b/code_test.go
@@ -691,3 +691,23 @@ func BenchmarkAppend(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkDecode(b *testing.B) {
+	b.Run("Simple", func(b *testing.B) {
+		b.ReportAllocs()
+		enc := Encode(1, 2, 256, 1.61, "abc")
+
+		for i := 0; i < b.N; i++ {
+			var (
+				i1, i2 int
+				u      uint64
+				f      float64
+				s      string
+			)
+			err := Decode(enc, &i1, &i2, &u, &f, &s)
+			if err != nil {
+				b.Fatalf("Decode: %v", err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
- The '%T' format specifier caused extra allocations in the Append function, even outside the default branch. The proposed change resolves this issue and enhances Append's performance by more than 2x, as measured in the accompanying benchmark.

- The same issue was affecting the performance of the Decode and RevAny functions.

- Fixes a typo in the package documentation.